### PR TITLE
fix isEqual in luxon utils

### DIFF
--- a/__tests__/calculations.test.ts
+++ b/__tests__/calculations.test.ts
@@ -183,6 +183,7 @@ describe("DateTime calculations", () => {
   utilsTest("isEqual", (date, utils) => {
     expect(utils.isEqual(utils.date(null), null)).toBeTruthy();
     expect(utils.isEqual(date, utils.date(TEST_TIMESTAMP))).toBeTruthy();
+    expect(utils.isEqual(null, utils.date(TEST_TIMESTAMP))).toBeFalsy();
   });
 
   utilsTest("parse", (date, utils, lib) => {

--- a/packages/luxon/src/luxon-utils.ts
+++ b/packages/luxon/src/luxon-utils.ts
@@ -67,7 +67,10 @@ export default class LuxonUtils implements IUtils<DateTime> {
       return true;
     }
 
-    return this.date(value).equals(this.date(comparing));
+    const date = this.date(value);
+    if (!date) return false;
+
+    return date.equals(this.date(comparing));
   }
 
   public isSameDay(value: DateTime, comparing: DateTime) {


### PR DESCRIPTION
- fixes https://github.com/dmtrKovalenko/material-ui-pickers/issues/870

disclaimer: I didn't really look at the pickers code yet. Wondering if it makes more sense to prevent the isEqual(null, sth) check somewhere in the code over there. Anyhow, it shouldn't fail