### PR TITLE
Fix TypeScript import from date-fns

### DIFF
--- a/packages/date-fns/src/date-fns-utils.ts
+++ b/packages/date-fns/src/date-fns-utils.ts
@@ -28,7 +28,7 @@ import startOfWeek from "date-fns/startOfWeek";
 import startOfYear from "date-fns/startOfYear";
 
 // Locale is not exported from date-fns, so we need to workaround that https://github.com/date-fns/date-fns/issues/932
-import SampleLocale from "date-fns/locale/en-US";
+import * as SampleLocale from "date-fns/locale/en-US";
 import { IUtils } from "@date-io/core/IUtils";
 
 type Locale = typeof SampleLocale;


### PR DESCRIPTION
This fixes TypeScript compilation when using date-fns@2.0.0-alpha.27