### PR TITLE
Change the semver rule for date-fns dependency

### DIFF
--- a/packages/date-fns/package.json
+++ b/packages/date-fns/package.json
@@ -30,13 +30,13 @@
   },
   "license": "MIT",
   "peerDependencies": {
-    "date-fns": "2.7.0"
+    "date-fns": "^2.7.0"
   },
   "dependencies": {
     "@date-io/core": "^1.3.11"
   },
   "devDependencies": {
-    "date-fns": "2.7.0",
+    "date-fns": "^2.7.0",
     "rollup": "^1.26.4",
     "typescript": "^3.7.2"
   },


### PR DESCRIPTION
It is better to use `^` in the version range for the date-fns peerDependency and devDependency.

Having the `^` will prevent warnings when installing `@date-io/date-fns`