### PR TITLE
Introduce new getFormatHelperText method

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,9 +52,11 @@ Implemented interface for now. If you can not find needed method please let us k
 export interface DateIOFormats<TLibFormatToken = string> {
   /** Localized full date, useful for accessibility @example "January 1st, 2019" */
   fullDate: TLibFormatToken;
-  /** Day format string extremely required to localize @example "Wed, Jan 1st" for US, "January 1st" for Europe */
+  /** Date format string with month and day of month @example "01 January" */
   normalDate: TLibFormatToken;
-  /** Shorter day format @example "Jan 1st" */
+  /** Date format string with weekday, month and day of month @example "Wed, Jan 1st" */
+  normalDateWithWeekday: TLibFormatToken;
+  /** Shorter day format @example "1 January" */
   shortDate: TLibFormatToken;
   /** Year format string @example "2019" */
   year: TLibFormatToken;
@@ -107,8 +109,13 @@ export interface IUtils<TDate> {
   // constructor (options?: { formats?: DateIOFormats, locale?: any, instance?: any });
 
   date(value?: any): TDate | null;
+  toJsDate(value: TDate): Date;
   parse(value: string, format: string): TDate | null;
+
+  getCurrentLocaleCode(): string;
   is12HourCycleInCurrentLocale(): boolean;
+  /** Returns user readable format (taking into account localized format tokens), useful to render helper text for input (e.g. placeholder). For luxon always returns empty string. */
+  getFormatHelperText(format: string): string;
 
   isNull(value: TDate | null): boolean;
   isValid(value: any): boolean;
@@ -128,10 +135,15 @@ export interface IUtils<TDate> {
   isBeforeYear(value: TDate, comparing: TDate): boolean;
   isBefore(value: TDate, comparing: TDate): boolean;
 
+  isWithinRange(value: TDate, range: [TDate, TDate]): boolean;
+
   startOfMonth(value: TDate): TDate;
   endOfMonth(value: TDate): TDate;
+  startOfWeek(value: TDate): TDate;
+  endOfWeek(value: TDate): TDate;
 
   addDays(value: TDate, count: number): TDate;
+  addMonths(value: TDate, count: number): TDate;
 
   startOfDay(value: TDate): TDate;
   endOfDay(value: TDate): TDate;
@@ -167,18 +179,5 @@ export interface IUtils<TDate> {
 
   /** Allow to customize displaying "am/pm" strings */
   getMeridiemText(ampm: "am" | "pm"): string;
-}
-```
-
-### Typescript
-
-The project itself written in typescript, so we are providing our own typescript definitions. But for the **moment** and **date-fns** users it is required to add `esModuleInterop` and `allowSyntheticDefaultImports` to your `tsconfig.json`
-
-```json
-{
-  "compilerOptions": {
-    "esModuleInterop": true,
-    "allowSyntheticDefaultImports": true
-  }
 }
 ```

--- a/__tests__/calculations.test.ts
+++ b/__tests__/calculations.test.ts
@@ -29,9 +29,8 @@ describe("DateTime calculations", () => {
   });
 
   utilsTest("addMonths", (date, utils, lib) => {
-    const result = utils.addMonths(date, 2);
-
-    expect(utils.format(result, "monthAndYear")).toBe("December 2018");
+    expect(utils.format(utils.addMonths(date, 2), "monthAndYear")).toBe("December 2018");
+    expect(utils.format(utils.addMonths(date, -2), "monthAndYear")).toBe("August 2018");
   });
 
   utilsTest("startOfDay", (date, utils, lib) => {

--- a/__tests__/localization.test.ts
+++ b/__tests__/localization.test.ts
@@ -176,26 +176,10 @@ describe("Dayjs -- Localization", () => {
 });
 
 describe("formatHelperText", () => {
-  it("DateFns -- getFormatHelperText", () => {
-    const utils = new DateFnsUtils();
-
-    expect(utils.getFormatHelperText(utils.formats.keyboardDate)).toBe("mm/dd/yyyy");
-    expect(utils.getFormatHelperText(utils.formats.keyboardDateTime12h)).toBe(
-      "mm/dd/yyyy hh:mm (a|p)m"
-    );
-  });
-
-  it("Moment -- getFormatHelperText", () => {
-    const utils = new MomentUtils();
-
-    expect(utils.getFormatHelperText(utils.formats.keyboardDate)).toBe("mm/dd/yyyy");
-    expect(utils.getFormatHelperText(utils.formats.keyboardDateTime12h)).toBe(
-      "mm/dd/yyyy hh:mm (a|p)m"
-    );
-  });
-
-  it("Dayjs -- getFormatHelperText", () => {
-    const utils = new DayjsUtils();
+  utilsTest("getFormatHelperText", (_, utils, lib) => {
+    if (lib === "Luxon") {
+      return;
+    }
 
     expect(utils.getFormatHelperText(utils.formats.keyboardDate)).toBe("mm/dd/yyyy");
     expect(utils.getFormatHelperText(utils.formats.keyboardDateTime12h)).toBe(

--- a/__tests__/localization.test.ts
+++ b/__tests__/localization.test.ts
@@ -175,7 +175,7 @@ describe("Dayjs -- Localization", () => {
   });
 });
 
-describe.only("formatHelperText", () => {
+describe("formatHelperText", () => {
   it("DateFns -- getFormatHelperText", () => {
     const utils = new DateFnsUtils();
 
@@ -188,18 +188,18 @@ describe.only("formatHelperText", () => {
   it("Moment -- getFormatHelperText", () => {
     const utils = new MomentUtils();
 
-    expect(utils.getFormatHelperText(utils.formats.keyboardDate)).toBe("dd/mm/yyyy");
+    expect(utils.getFormatHelperText(utils.formats.keyboardDate)).toBe("mm/dd/yyyy");
     expect(utils.getFormatHelperText(utils.formats.keyboardDateTime12h)).toBe(
-      "dd/mm/yyyy hh:mm (a|p)m"
+      "mm/dd/yyyy hh:mm (a|p)m"
     );
   });
 
   it("Dayjs -- getFormatHelperText", () => {
-    const utils = new MomentUtils();
+    const utils = new DayjsUtils();
 
-    expect(utils.getFormatHelperText(utils.formats.keyboardDate)).toBe("dd/mm/yyyy");
+    expect(utils.getFormatHelperText(utils.formats.keyboardDate)).toBe("mm/dd/yyyy");
     expect(utils.getFormatHelperText(utils.formats.keyboardDateTime12h)).toBe(
-      "dd/mm/yyyy hh:mm (a|p)m"
+      "mm/dd/yyyy hh:mm (a|p)m"
     );
   });
 

--- a/__tests__/localization.test.ts
+++ b/__tests__/localization.test.ts
@@ -174,3 +174,38 @@ describe("Dayjs -- Localization", () => {
     });
   });
 });
+
+describe.only("formatHelperText", () => {
+  it("DateFns -- getFormatHelperText", () => {
+    const utils = new DateFnsUtils();
+
+    expect(utils.getFormatHelperText(utils.formats.keyboardDate)).toBe("mm/dd/yyyy");
+    expect(utils.getFormatHelperText(utils.formats.keyboardDateTime12h)).toBe(
+      "mm/dd/yyyy hh:mm (a|p)m"
+    );
+  });
+
+  it("Moment -- getFormatHelperText", () => {
+    const utils = new MomentUtils();
+
+    expect(utils.getFormatHelperText(utils.formats.keyboardDate)).toBe("dd/mm/yyyy");
+    expect(utils.getFormatHelperText(utils.formats.keyboardDateTime12h)).toBe(
+      "dd/mm/yyyy hh:mm (a|p)m"
+    );
+  });
+
+  it("Dayjs -- getFormatHelperText", () => {
+    const utils = new MomentUtils();
+
+    expect(utils.getFormatHelperText(utils.formats.keyboardDate)).toBe("dd/mm/yyyy");
+    expect(utils.getFormatHelperText(utils.formats.keyboardDateTime12h)).toBe(
+      "dd/mm/yyyy hh:mm (a|p)m"
+    );
+  });
+
+  it("Luxon -- getFormatHelperText should return empty string", () => {
+    const utils = new LuxonUtils();
+
+    expect(utils.getFormatHelperText(utils.formats.keyboardDate)).toBe("");
+  });
+});

--- a/packages/core/IUtils.d.ts
+++ b/packages/core/IUtils.d.ts
@@ -63,6 +63,8 @@ export interface IUtils<TDate> {
 
   getCurrentLocaleCode(): string;
   is12HourCycleInCurrentLocale(): boolean;
+  /** Returns user readable format (taking into account localized format tokens), useful to render helper text for input (e.g. placeholder). For luxon always returns empty string. */
+  getFormatHelperText(format: string): string;
 
   isNull(value: TDate | null): boolean;
   isValid(value: any): boolean;

--- a/packages/dayjs/src/dayjs-utils.ts
+++ b/packages/dayjs/src/dayjs-utils.ts
@@ -87,7 +87,8 @@ export default class DayjsUtils implements IUtils<defaultDayjs.Dayjs> {
       .map(token => {
         var firstCharacter = token[0];
         if (firstCharacter === "L") {
-          return this.rawDayJsInstance.Ls[this.locale || "en"]?.formats[token];
+          /* istanbul ignore next */
+          return this.rawDayJsInstance.Ls[this.locale || "en"]?.formats[token] ?? token;
         }
         return token;
       })

--- a/packages/dayjs/src/dayjs-utils.ts
+++ b/packages/dayjs/src/dayjs-utils.ts
@@ -79,6 +79,23 @@ export default class DayjsUtils implements IUtils<defaultDayjs.Dayjs> {
     return this.locale || "en";
   }
 
+  public getFormatHelperText(format: string) {
+    // @see https://github.com/iamkun/dayjs/blob/dev/src/plugin/localizedFormat/index.js
+    var localFormattingTokens = /(\[[^\[]*\])|(\\)?(LTS|LT|LL?L?L?)|./g;
+    return format
+      .match(localFormattingTokens)
+      .map(token => {
+        var firstCharacter = token[0];
+        if (firstCharacter === "L") {
+          return this.rawDayJsInstance.Ls[this.locale || "en"]?.formats[token];
+        }
+        return token;
+      })
+      .join("")
+      .replace(/a/gi, "(a|p)m")
+      .toLocaleLowerCase();
+  }
+
   public parse(value: any, format: any) {
     if (value === "") {
       return null;

--- a/packages/luxon/src/luxon-utils.ts
+++ b/packages/luxon/src/luxon-utils.ts
@@ -83,6 +83,11 @@ export default class LuxonUtils implements IUtils<DateTime> {
     );
   }
 
+  public getFormatHelperText(format: string) {
+    // Unfortunately there is no way for luxon to retrieve readable formats from localized format
+    return "";
+  }
+
   public getCurrentLocaleCode() {
     return this.locale || Settings.defaultLocale;
   }

--- a/packages/luxon/src/luxon-utils.ts
+++ b/packages/luxon/src/luxon-utils.ts
@@ -88,6 +88,7 @@ export default class LuxonUtils implements IUtils<DateTime> {
     return "";
   }
 
+  /* istanbul ignore next */
   public getCurrentLocaleCode() {
     return this.locale || Settings.defaultLocale;
   }

--- a/packages/moment/src/moment-utils.ts
+++ b/packages/moment/src/moment-utils.ts
@@ -1,4 +1,4 @@
-import defaultMoment from "moment";
+import defaultMoment, { LongDateFormatKey } from "moment";
 import { IUtils, DateIOFormats } from "@date-io/core/IUtils";
 
 interface Opts {
@@ -53,6 +53,24 @@ export default class MomentUtils implements IUtils<defaultMoment.Moment> {
         .localeData()
         .longDateFormat("LT")
     );
+  }
+
+  public getFormatHelperText(format: string) {
+    // @see https://github.com/moment/moment/blob/develop/src/lib/format/format.js#L6
+    const localFormattingTokens = /(\[[^\[]*\])|(\\)?(LTS|LT|LL?L?L?|l{1,4})|./g;
+    return format
+      .match(localFormattingTokens)
+      .map(token => {
+        const firstCharacter = token[0];
+        if (firstCharacter === "L" || firstCharacter === ";") {
+          return this.moment.localeData().longDateFormat(token as LongDateFormatKey);
+        }
+
+        return token;
+      })
+      .join("")
+      .replace(/a/gi, "(a|p)m")
+      .toLocaleLowerCase();
   }
 
   public getCurrentLocaleCode() {


### PR DESCRIPTION
Returns user-readable format taking into account localized format tokens. Useful to render helper text for input (e.g. placeholder). For luxon always returns an empty string. 