### PR TITLE
make startOfWeek and endOfWeek locale aware

### DIFF
--- a/__tests__/localization.test.ts
+++ b/__tests__/localization.test.ts
@@ -42,6 +42,22 @@ describe("DateFns -- Localization", () => {
   it("getCurrentLocaleCode: returns locale code", () => {
     expect(RuDateFnsUtils.getCurrentLocaleCode()).toBe("ru");
   });
+  it("startOfWeek: returns correct start of week for locale", () => {
+    expect(
+      RuDateFnsUtils.formatByString(
+        RuDateFnsUtils.startOfWeek(RuDateFnsUtils.date(TEST_TIMESTAMP)),
+        "d"
+      )
+    ).toEqual("29");
+  });
+  it("endOfWeek: returns correct end of week for locale", () => {
+    expect(
+      RuDateFnsUtils.formatByString(
+        RuDateFnsUtils.endOfWeek(RuDateFnsUtils.date(TEST_TIMESTAMP)),
+        "d"
+      )
+    ).toEqual("4");
+  });
 });
 
 describe("Luxon -- Localization", () => {

--- a/packages/date-fns/src/date-fns-utils.ts
+++ b/packages/date-fns/src/date-fns-utils.ts
@@ -60,7 +60,7 @@ const defaultFormats: DateIOFormats = {
   normalDateWithWeekday: "EEE, MMM d",
   seconds: "ss",
   shortDate: "MMM d",
-  year: "yyyy"
+  year: "yyyy",
 };
 
 export default class DateFnsUtils implements IUtils<Date> {
@@ -69,7 +69,7 @@ export default class DateFnsUtils implements IUtils<Date> {
 
   constructor({
     locale,
-    formats
+    formats,
   }: { formats?: Partial<DateIOFormats>; locale?: Locale } = {}) {
     this.locale = locale;
     this.formats = Object.assign({}, defaultFormats, formats);
@@ -92,7 +92,7 @@ export default class DateFnsUtils implements IUtils<Date> {
     const locale = this.locale || defaultLocale;
     return format
       .match(longFormatRegexp)
-      .map(token => {
+      .map((token) => {
         const firstCharacter = token[0];
         if (firstCharacter === "p" || firstCharacter === "P") {
           const longFormatter = longFormatters[firstCharacter];
@@ -186,11 +186,11 @@ export default class DateFnsUtils implements IUtils<Date> {
   }
 
   public startOfWeek(value: Date) {
-    return startOfWeek(value);
+    return startOfWeek(value, { locale: this.locale });
   }
 
   public endOfWeek(value: Date) {
-    return endOfWeek(value);
+    return endOfWeek(value, { locale: this.locale });
   }
 
   public getYear(value: Date) {
@@ -316,8 +316,8 @@ export default class DateFnsUtils implements IUtils<Date> {
     const now = new Date();
     return eachDayOfInterval({
       start: startOfWeek(now, { locale: this.locale }),
-      end: endOfWeek(now, { locale: this.locale })
-    }).map(day => this.formatByString(day, "EEEEEE"));
+      end: endOfWeek(now, { locale: this.locale }),
+    }).map((day) => this.formatByString(day, "EEEEEE"));
   }
 
   public getWeekArray(date: Date) {


### PR DESCRIPTION
One thing that I'm not totally clear about is why my local prettier is creating changes that are different from yours, but the only real change is the adding the tests and then passing locale through those two functions