### PR TITLE
Fix mutation of date param in MomentUtils.formatByString

### DIFF
--- a/packages/moment/src/moment-utils.ts
+++ b/packages/moment/src/moment-utils.ts
@@ -149,8 +149,9 @@ export default class MomentUtils implements IUtils<defaultMoment.Moment> {
   }
 
   public formatByString(date: Moment, formatString: string) {
-    date.locale(this.locale);
-    return date.format(formatString);
+    const clonedDate = date.clone();
+    clonedDate.locale(this.locale);
+    return clonedDate.format(formatString);
   }
 
   public formatNumber(numberToFormat: string) {


### PR DESCRIPTION
`MomentUtils.formatByString` takes the `date` param and changes it by setting a locale.

Everywhere else in the file `clone` is used but not here. So it's an unexpected mutation of a passed param and it blows up if `date` is frozen.

The only changes are in the `formatByString`, the rest was applied by husky on commit.

