### PR TITLE
date-fns-jalali utils added

### DIFF
--- a/packages/date-fns-jalali/package.json
+++ b/packages/date-fns-jalali/package.json
@@ -1,0 +1,44 @@
+{
+  "name": "@date-io/date-fns",
+  "version": "1.3.13",
+  "description": "Abstraction over common javascript date management libraries",
+  "main": "build/index.js",
+  "module": "build/index.esm.js",
+  "typings": "build/index.d.ts",
+  "scripts": {
+    "build": "rollup -c && tsc -p tsconfig.declaration.json"
+  },
+  "bugs": {
+    "url": "https://github.com/dmtrKovalenko/date-io/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/dmtrKovalenko/date-io"
+  },
+  "keywords": [
+    "date",
+    "time",
+    "date-io",
+    "picker",
+    "date-fns",
+    "moment",
+    "luxon"
+  ],
+  "author": {
+    "name": "Dmitriy Kovalenko",
+    "email": "dmtr.kovalenko@outlook.com"
+  },
+  "license": "MIT",
+  "peerDependencies": {
+    "date-fns": "^2.0.0"
+  },
+  "dependencies": {
+    "@date-io/core": "^1.3.13"
+  },
+  "devDependencies": {
+    "date-fns": "2.8.1",
+    "rollup": "^1.27.7",
+    "typescript": "^3.7.2"
+  },
+  "gitHead": "b288f4a6e493cefa32226e9363adea4fe1184168"
+}

--- a/packages/date-fns-jalali/package.json
+++ b/packages/date-fns-jalali/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@date-io/date-fns",
+  "name": "@date-io/date-fns-jalali",
   "version": "1.3.13",
   "description": "Abstraction over common javascript date management libraries",
   "main": "build/index.js",
@@ -20,6 +20,7 @@
     "time",
     "date-io",
     "picker",
+    "date-fns-jalali",
     "date-fns",
     "moment",
     "luxon"
@@ -30,13 +31,13 @@
   },
   "license": "MIT",
   "peerDependencies": {
-    "date-fns": "^2.0.0"
+    "date-fns-jalali": "^2.0.0"
   },
   "dependencies": {
     "@date-io/core": "^1.3.13"
   },
   "devDependencies": {
-    "date-fns": "2.8.1",
+    "date-fns-jalali": "2.13.0-0",
     "rollup": "^1.27.7",
     "typescript": "^3.7.2"
   },

--- a/packages/date-fns-jalali/package.json
+++ b/packages/date-fns-jalali/package.json
@@ -37,7 +37,7 @@
     "@date-io/core": "^1.3.13"
   },
   "devDependencies": {
-    "date-fns-jalali": "2.13.0-0",
+    "date-fns-jalali": "^2.13.0-0",
     "rollup": "^1.27.7",
     "typescript": "^3.7.2"
   },

--- a/packages/date-fns-jalali/rollup.config.js
+++ b/packages/date-fns-jalali/rollup.config.js
@@ -1,0 +1,4 @@
+import typescript from 'typescript'
+import { createRollupConfig } from '@date-io/core/dev-utils'
+
+export default createRollupConfig(typescript)

--- a/packages/date-fns-jalali/src/date-fns-utils.ts
+++ b/packages/date-fns-jalali/src/date-fns-utils.ts
@@ -1,0 +1,319 @@
+import addDays from "date-fns/addDays";
+import addMonths from "date-fns/addMonths";
+import addYears from "date-fns/addYears";
+import differenceInMilliseconds from "date-fns/differenceInMilliseconds";
+import eachDayOfInterval from "date-fns/eachDayOfInterval";
+import endOfDay from "date-fns/endOfDay";
+import endOfWeek from "date-fns/endOfWeek";
+import endOfYear from "date-fns/endOfYear";
+import format from "date-fns/format";
+import getHours from "date-fns/getHours";
+import getSeconds from "date-fns/getSeconds";
+import getYear from "date-fns/getYear";
+import isAfter from "date-fns/isAfter";
+import isBefore from "date-fns/isBefore";
+import isEqual from "date-fns/isEqual";
+import isSameDay from "date-fns/isSameDay";
+import isSameYear from "date-fns/isSameYear";
+import isSameMonth from "date-fns/isSameMonth";
+import isSameHour from "date-fns/isSameHour";
+import isValid from "date-fns/isValid";
+import dateFnsParse from "date-fns/parse";
+import setHours from "date-fns/setHours";
+import setMinutes from "date-fns/setMinutes";
+import setMonth from "date-fns/setMonth";
+import setSeconds from "date-fns/setSeconds";
+import setYear from "date-fns/setYear";
+import startOfDay from "date-fns/startOfDay";
+import startOfMonth from "date-fns/startOfMonth";
+import endOfMonth from "date-fns/endOfMonth";
+import startOfWeek from "date-fns/startOfWeek";
+import startOfYear from "date-fns/startOfYear";
+
+// Locale is not exported from date-fns, so we need to workaround that https://github.com/date-fns/date-fns/issues/932
+import SampleLocale from "date-fns/locale/en-US";
+import { IUtils } from "@date-io/core/IUtils";
+
+type Locale = typeof SampleLocale;
+
+export default class DateFnsUtils implements IUtils<Date> {
+  public locale?: Locale;
+
+  public yearFormat = "yyyy";
+
+  public yearMonthFormat = "MMMM yyyy";
+
+  public dateTime12hFormat = "MMMM do hh:mm aaaa";
+
+  public dateTime24hFormat = "MMMM do HH:mm";
+
+  public time12hFormat = "hh:mm a";
+
+  public time24hFormat = "HH:mm";
+
+  public dateFormat = "MMMM do";
+
+  constructor({ locale }: { locale?: Locale } = {}) {
+    this.locale = locale;
+  }
+
+  // Note: date-fns input types are more lenient than this adapter, so we need to expose our more
+  // strict signature and delegate to the more lenient signature. Otherwise, we have downstream type errors upon usage.
+
+  public addDays(value: Date, count: number) {
+    return addDays(value, count);
+  }
+
+  public isValid(value: any) {
+    return isValid(this.date(value));
+  }
+
+  public getDiff(value: Date, comparing: Date | string) {
+    return differenceInMilliseconds(value, this.date(comparing));
+  }
+
+  public isAfter(value: Date, comparing: Date) {
+    return isAfter(value, comparing);
+  }
+
+  public isBefore(value: Date, comparing: Date) {
+    return isBefore(value, comparing);
+  }
+
+  public startOfDay(value: Date) {
+    return startOfDay(value);
+  }
+
+  public endOfDay(value: Date) {
+    return endOfDay(value);
+  }
+
+  public getHours(value: Date) {
+    return getHours(value);
+  }
+
+  public setHours(value: Date, count: number) {
+    return setHours(value, count);
+  }
+
+  public setMinutes(value: Date, count: number) {
+    return setMinutes(value, count);
+  }
+
+  public getSeconds(value: Date) {
+    return getSeconds(value);
+  }
+
+  public setSeconds(value: Date, count: number) {
+    return setSeconds(value, count);
+  }
+
+  public isSameDay(value: Date, comparing: Date) {
+    return isSameDay(value, comparing);
+  }
+
+  public isSameMonth(value: Date, comparing: Date) {
+    return isSameMonth(value, comparing);
+  }
+
+  public isSameYear(value: Date, comparing: Date) {
+    return isSameYear(value, comparing);
+  }
+
+  public isSameHour(value: Date, comparing: Date) {
+    return isSameHour(value, comparing);
+  }
+
+  public startOfMonth(value: Date) {
+    return startOfMonth(value);
+  }
+
+  public endOfMonth(value: Date) {
+    return endOfMonth(value);
+  }
+
+  public getYear(value: Date) {
+    return getYear(value);
+  }
+
+  public setYear(value: Date, count: number) {
+    return setYear(value, count);
+  }
+
+  public date(value?: any) {
+    if (typeof value === "undefined") {
+      return new Date();
+    }
+
+    if (value === null) {
+      return null;
+    }
+
+    return new Date(value);
+  }
+
+  public parse(value: string, formatString: string) {
+    if (value === "") {
+      return null;
+    }
+
+    return dateFnsParse(value, formatString, new Date(), { locale: this.locale });
+  }
+
+  public format(date: Date, formatString: string) {
+    return format(date, formatString, { locale: this.locale });
+  }
+
+  public isEqual(date: any, comparing: any) {
+    if (date === null && comparing === null) {
+      return true;
+    }
+
+    return isEqual(date, comparing);
+  }
+
+  public isNull(date: Date) {
+    return date === null;
+  }
+
+  public isAfterDay(date: Date, value: Date) {
+    return isAfter(date, endOfDay(value));
+  }
+
+  public isBeforeDay(date: Date, value: Date) {
+    return isBefore(date, startOfDay(value));
+  }
+
+  public isBeforeYear(date: Date, value: Date) {
+    return isBefore(date, startOfYear(value));
+  }
+
+  public isAfterYear(date: Date, value: Date) {
+    return isAfter(date, endOfYear(value));
+  }
+
+  public formatNumber(numberToFormat: string) {
+    return numberToFormat;
+  }
+
+  public getMinutes(date: Date) {
+    return date.getMinutes();
+  }
+
+  public getMonth(date: Date) {
+    return date.getMonth();
+  }
+
+  public setMonth(date: Date, count: number) {
+    return setMonth(date, count);
+  }
+
+  public getMeridiemText(ampm: "am" | "pm") {
+    return ampm === "am" ? "AM" : "PM";
+  }
+
+  public getNextMonth(date: Date) {
+    return addMonths(date, 1);
+  }
+
+  public getPreviousMonth(date: Date) {
+    return addMonths(date, -1);
+  }
+
+  public getMonthArray(date: Date) {
+    const firstMonth = startOfYear(date);
+    const monthArray = [firstMonth];
+
+    while (monthArray.length < 12) {
+      const prevMonth = monthArray[monthArray.length - 1];
+      monthArray.push(this.getNextMonth(prevMonth));
+    }
+
+    return monthArray;
+  }
+
+  public mergeDateAndTime(date: Date, time: Date) {
+    return this.setMinutes(
+      this.setHours(date, this.getHours(time)),
+      this.getMinutes(time)
+    );
+  }
+
+  public getWeekdays() {
+    const now = new Date();
+    return eachDayOfInterval({
+      start: startOfWeek(now, { locale: this.locale }),
+      end: endOfWeek(now, { locale: this.locale })
+    }).map(day => this.format(day, "EEEEEE"));
+  }
+
+  public getWeekArray(date: Date) {
+    const start = startOfWeek(startOfMonth(date), { locale: this.locale });
+    const end = endOfWeek(endOfMonth(date), { locale: this.locale });
+
+    let count = 0;
+    let current = start;
+    const nestedWeeks: Date[][] = [];
+
+    while (isBefore(current, end)) {
+      const weekNumber = Math.floor(count / 7);
+      nestedWeeks[weekNumber] = nestedWeeks[weekNumber] || [];
+      nestedWeeks[weekNumber].push(current);
+      current = addDays(current, 1);
+      count += 1;
+    }
+
+    return nestedWeeks;
+  }
+
+  public getYearRange(start: Date, end: Date) {
+    const startDate = startOfYear(start);
+    const endDate = endOfYear(end);
+    const years: Date[] = [];
+
+    let current = startDate;
+    while (isBefore(current, endDate)) {
+      years.push(current);
+      current = addYears(current, 1);
+    }
+
+    return years;
+  }
+
+  // displaying methpds
+  public getCalendarHeaderText(date: Date) {
+    return this.format(date, this.yearMonthFormat);
+  }
+
+  public getYearText(date: Date) {
+    return this.format(date, "yyyy");
+  }
+
+  public getDatePickerHeaderText(date: Date) {
+    return this.format(date, "EEE, MMM d");
+  }
+
+  public getDateTimePickerHeaderText(date: Date) {
+    return this.format(date, "MMM d");
+  }
+
+  public getMonthText(date: Date) {
+    return this.format(date, "MMMM");
+  }
+
+  public getDayText(date: Date) {
+    return this.format(date, "d");
+  }
+
+  public getHourText(date: Date, ampm: boolean) {
+    return this.format(date, ampm ? "hh" : "HH");
+  }
+
+  public getMinuteText(date: Date) {
+    return this.format(date, "mm");
+  }
+
+  public getSecondText(date: Date) {
+    return this.format(date, "ss");
+  }
+}

--- a/packages/date-fns-jalali/src/date-fns-utils.ts
+++ b/packages/date-fns-jalali/src/date-fns-utils.ts
@@ -1,57 +1,59 @@
-import addDays from "date-fns/addDays";
-import addMonths from "date-fns/addMonths";
-import addYears from "date-fns/addYears";
-import differenceInMilliseconds from "date-fns/differenceInMilliseconds";
-import eachDayOfInterval from "date-fns/eachDayOfInterval";
-import endOfDay from "date-fns/endOfDay";
-import endOfWeek from "date-fns/endOfWeek";
-import endOfYear from "date-fns/endOfYear";
-import format from "date-fns/format";
-import getHours from "date-fns/getHours";
-import getSeconds from "date-fns/getSeconds";
-import getYear from "date-fns/getYear";
-import isAfter from "date-fns/isAfter";
-import isBefore from "date-fns/isBefore";
-import isEqual from "date-fns/isEqual";
-import isSameDay from "date-fns/isSameDay";
-import isSameYear from "date-fns/isSameYear";
-import isSameMonth from "date-fns/isSameMonth";
-import isSameHour from "date-fns/isSameHour";
-import isValid from "date-fns/isValid";
-import dateFnsParse from "date-fns/parse";
-import setHours from "date-fns/setHours";
-import setMinutes from "date-fns/setMinutes";
-import setMonth from "date-fns/setMonth";
-import setSeconds from "date-fns/setSeconds";
-import setYear from "date-fns/setYear";
-import startOfDay from "date-fns/startOfDay";
-import startOfMonth from "date-fns/startOfMonth";
-import endOfMonth from "date-fns/endOfMonth";
-import startOfWeek from "date-fns/startOfWeek";
-import startOfYear from "date-fns/startOfYear";
+import addDays from "date-fns-jalali/addDays";
+import addMonths from "date-fns-jalali/addMonths";
+import addYears from "date-fns-jalali/addYears";
+import differenceInMilliseconds from "date-fns-jalali/differenceInMilliseconds";
+import eachDayOfInterval from "date-fns-jalali/eachDayOfInterval";
+import endOfDay from "date-fns-jalali/endOfDay";
+import endOfWeek from "date-fns-jalali/endOfWeek";
+import endOfYear from "date-fns-jalali/endOfYear";
+import format from "date-fns-jalali/format";
+import getHours from "date-fns-jalali/getHours";
+import getSeconds from "date-fns-jalali/getSeconds";
+import getYear from "date-fns-jalali/getYear";
+import getMonth from "date-fns-jalali/getMonth";
+import getMinutes from "date-fns-jalali/getMinutes";
+import isAfter from "date-fns-jalali/isAfter";
+import isBefore from "date-fns-jalali/isBefore";
+import isEqual from "date-fns-jalali/isEqual";
+import isSameDay from "date-fns-jalali/isSameDay";
+import isSameYear from "date-fns-jalali/isSameYear";
+import isSameMonth from "date-fns-jalali/isSameMonth";
+import isSameHour from "date-fns-jalali/isSameHour";
+import isValid from "date-fns-jalali/isValid";
+import dateFnsParse from "date-fns-jalali/parse";
+import setHours from "date-fns-jalali/setHours";
+import setMinutes from "date-fns-jalali/setMinutes";
+import setMonth from "date-fns-jalali/setMonth";
+import setSeconds from "date-fns-jalali/setSeconds";
+import setYear from "date-fns-jalali/setYear";
+import startOfDay from "date-fns-jalali/startOfDay";
+import startOfMonth from "date-fns-jalali/startOfMonth";
+import endOfMonth from "date-fns-jalali/endOfMonth";
+import startOfWeek from "date-fns-jalali/startOfWeek";
+import startOfYear from "date-fns-jalali/startOfYear";
 
 // Locale is not exported from date-fns, so we need to workaround that https://github.com/date-fns/date-fns/issues/932
-import SampleLocale from "date-fns/locale/en-US";
+import SampleLocale from "date-fns-jalali/locale/fa-jalali-IR";
 import { IUtils } from "@date-io/core/IUtils";
 
 type Locale = typeof SampleLocale;
 
-export default class DateFnsUtils implements IUtils<Date> {
+export default class DateFnsJalaliUtils implements IUtils<Date> {
   public locale?: Locale;
 
   public yearFormat = "yyyy";
 
   public yearMonthFormat = "MMMM yyyy";
 
-  public dateTime12hFormat = "MMMM do hh:mm aaaa";
+  public dateTime12hFormat = "yyyy/MM/dd hh:mm aaaa";
 
-  public dateTime24hFormat = "MMMM do HH:mm";
+  public dateTime24hFormat = "yyyy/MM/dd HH:mm";
 
   public time12hFormat = "hh:mm a";
 
   public time24hFormat = "HH:mm";
 
-  public dateFormat = "MMMM do";
+  public dateFormat = "yyyy/MM/dd";
 
   constructor({ locale }: { locale?: Locale } = {}) {
     this.locale = locale;
@@ -140,6 +142,8 @@ export default class DateFnsUtils implements IUtils<Date> {
     return setYear(value, count);
   }
 
+  public date(value?: null): null;
+  public date(value?: string | number | Date): Date;
   public date(value?: any) {
     if (typeof value === "undefined") {
       return new Date();
@@ -197,11 +201,11 @@ export default class DateFnsUtils implements IUtils<Date> {
   }
 
   public getMinutes(date: Date) {
-    return date.getMinutes();
+    return getMinutes(date);
   }
 
   public getMonth(date: Date) {
-    return date.getMonth();
+    return getMonth(date);
   }
 
   public setMonth(date: Date, count: number) {
@@ -244,7 +248,7 @@ export default class DateFnsUtils implements IUtils<Date> {
     return eachDayOfInterval({
       start: startOfWeek(now, { locale: this.locale }),
       end: endOfWeek(now, { locale: this.locale })
-    }).map(day => this.format(day, "EEEEEE"));
+    }).map(day => this.format(day, "EEEEE"));
   }
 
   public getWeekArray(date: Date) {
@@ -280,7 +284,7 @@ export default class DateFnsUtils implements IUtils<Date> {
     return years;
   }
 
-  // displaying methpds
+  // displaying methods
   public getCalendarHeaderText(date: Date) {
     return this.format(date, this.yearMonthFormat);
   }
@@ -290,7 +294,7 @@ export default class DateFnsUtils implements IUtils<Date> {
   }
 
   public getDatePickerHeaderText(date: Date) {
-    return this.format(date, "EEE, MMM d");
+    return this.format(date, "EEE, d MMMM");
   }
 
   public getDateTimePickerHeaderText(date: Date) {

--- a/packages/date-fns-jalali/src/index.ts
+++ b/packages/date-fns-jalali/src/index.ts
@@ -1,0 +1,2 @@
+import "../type/index";
+export { default } from "./date-fns-utils";

--- a/packages/date-fns-jalali/tsconfig.declaration.json
+++ b/packages/date-fns-jalali/tsconfig.declaration.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../tsconfig.declaration.base.json",
+  "compilerOptions": {
+    "declarationDir": "build"
+  },
+  "include": ["src/*.ts"]
+}

--- a/packages/date-fns-jalali/type/index.d.ts
+++ b/packages/date-fns-jalali/type/index.d.ts
@@ -1,0 +1,3 @@
+declare module "@date-io/type" {
+  export type DateType = Date;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2214,6 +2214,11 @@ data-urls@^1.0.0:
     whatwg-mimetype "^2.2.0"
     whatwg-url "^7.0.0"
 
+date-fns-jalali@2.13.0-0:
+  version "2.13.0-0"
+  resolved "https://registry.yarnpkg.com/date-fns-jalali/-/date-fns-jalali-2.13.0-0.tgz#9e9d9d4a63910654aa72a550c55af9a80e89c060"
+  integrity sha512-yjlI9O18Z6ryGNagryrLO8OQ+3rishM3+A0UOX2UX10cWMn2NTlQcQ+ywTEJvF5IJz0FwX/slt2nCcpyQ/c8gw==
+
 date-fns@2.8.1:
   version "2.8.1"
   resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-2.8.1.tgz#2109362ccb6c87c3ca011e9e31f702bc09e4123b"


### PR DESCRIPTION
`date-fns-jalali` is a package that supports Jalali calendar with the same API as `date-fns`. In this PR `@date-io/date-fns-jalali` package is added based on `@date-io/date-fns v1.3.13`

In order to review this PR you just need to read `Use date-fns-jalali` [commit][e7bbea3]. at `Init date-io/date-fns-jalali` [commit][bf7267e] `date-fns` directory is coppied in to `date-fns-jalali` directory


[e7bbea3]: https://github.com/dmtrKovalenko/date-io/commit/e7bbea3c43f54e63b3720b11e06466ccb7d75289
[bf7267e]: https://github.com/dmtrKovalenko/date-io/commit/bf7267eff5ee78e172d9b26bda95c3a6cd76cb55