### PR TITLE
Add `lib` name to the adapter interface

### DIFF
--- a/packages/core/IUtils.d.ts
+++ b/packages/core/IUtils.d.ts
@@ -66,6 +66,7 @@ export interface IUtils<TDate> {
   locale?: any;
   moment?: any;
   dayjs?: any;
+  /** Name of the library that is used right now */
   lib: string;
 
   // constructor (options?: { formats?: DateIOFormats, locale?: any, instance?: any });

--- a/packages/core/IUtils.d.ts
+++ b/packages/core/IUtils.d.ts
@@ -1,3 +1,5 @@
+import { SupportOptionRange } from "prettier";
+
 /**
  * Localized output will of course vary based on the locale and date library used. Inline examples here are based on
  * using `moment` with the `en-US` locale.
@@ -64,6 +66,7 @@ export interface IUtils<TDate> {
   locale?: any;
   moment?: any;
   dayjs?: any;
+  lib: string;
 
   // constructor (options?: { formats?: DateIOFormats, locale?: any, instance?: any });
 

--- a/packages/date-fns-jalali/src/date-fns-jalali-utils.ts
+++ b/packages/date-fns-jalali/src/date-fns-jalali-utils.ts
@@ -82,6 +82,7 @@ var symbolMap = {
 };
 
 export default class DateFnsJalaliUtils implements IUtils<Date> {
+  public lib = "date-fns-jalali";
   public locale?: Locale;
   public formats: DateIOFormats;
 

--- a/packages/date-fns/src/date-fns-utils.ts
+++ b/packages/date-fns/src/date-fns-utils.ts
@@ -63,16 +63,17 @@ const defaultFormats: DateIOFormats = {
   normalDateWithWeekday: "EEE, MMM d",
   seconds: "ss",
   shortDate: "MMM d",
-  year: "yyyy"
+  year: "yyyy",
 };
 
 export default class DateFnsUtils implements IUtils<Date> {
+  public lib = "date-fns";
   public locale?: Locale;
   public formats: DateIOFormats;
 
   constructor({
     locale,
-    formats
+    formats,
   }: { formats?: Partial<DateIOFormats>; locale?: Locale } = {}) {
     this.locale = locale;
     this.formats = Object.assign({}, defaultFormats, formats);
@@ -95,7 +96,7 @@ export default class DateFnsUtils implements IUtils<Date> {
     const locale = this.locale || defaultLocale;
     return format
       .match(longFormatRegexp)
-      .map(token => {
+      .map((token) => {
         const firstCharacter = token[0];
         if (firstCharacter === "p" || firstCharacter === "P") {
           const longFormatter = longFormatters[firstCharacter];
@@ -319,8 +320,8 @@ export default class DateFnsUtils implements IUtils<Date> {
     const now = new Date();
     return eachDayOfInterval({
       start: startOfWeek(now, { locale: this.locale }),
-      end: endOfWeek(now, { locale: this.locale })
-    }).map(day => this.formatByString(day, "EEEEEE"));
+      end: endOfWeek(now, { locale: this.locale }),
+    }).map((day) => this.formatByString(day, "EEEEEE"));
   }
 
   public getWeekArray(date: Date) {

--- a/packages/dayjs/src/dayjs-utils.ts
+++ b/packages/dayjs/src/dayjs-utils.ts
@@ -61,6 +61,7 @@ const localizedFormats = {
 
 export default class DayjsUtils implements IUtils<defaultDayjs.Dayjs> {
   public rawDayJsInstance: typeof defaultDayjs;
+  public lib = "dayjs";
   public dayjs: Constructor;
   public locale?: string;
   public formats: DateIOFormats;

--- a/packages/hijri/src/hijri-utils.ts
+++ b/packages/hijri/src/hijri-utils.ts
@@ -55,6 +55,7 @@ const defaultFormats: DateIOFormats = {
 
 export default class MomentUtils extends DefaultMomentUtils {
   public moment: typeof iMoment;
+  public lib = "moment=hijiri";
   public locale?: string;
   public formats: DateIOFormats;
 

--- a/packages/jalaali/src/jalaali-utils.ts
+++ b/packages/jalaali/src/jalaali-utils.ts
@@ -53,6 +53,7 @@ const defaultFormats: DateIOFormats = {
 };
 
 export default class MomentUtils extends DefaultMomentUtils {
+  public lib = "moment-jalaali";
   public moment: typeof jMoment;
   public locale?: string;
   public formats: DateIOFormats;

--- a/packages/luxon/src/luxon-utils.ts
+++ b/packages/luxon/src/luxon-utils.ts
@@ -32,6 +32,7 @@ const defaultFormats: DateIOFormats = {
 };
 
 export default class LuxonUtils implements IUtils<DateTime> {
+  public lib = "luxon";
   public locale: string;
   public formats: DateIOFormats;
 

--- a/packages/moment/src/moment-utils.ts
+++ b/packages/moment/src/moment-utils.ts
@@ -40,6 +40,7 @@ const defaultFormats: DateIOFormats = {
 
 export default class MomentUtils implements IUtils<defaultMoment.Moment> {
   public moment: typeof defaultMoment;
+  public lib = "moment";
   public locale?: string;
   public formats: DateIOFormats;
 


### PR DESCRIPTION
Add new `lib` property to the adapter in order to make possible to `/disable/add` some functionality based on the adapter. 

```tsx
class Adapter { 
   public string: string;
}
```