### PR TITLE
Fix DST bug in safari

### DIFF
--- a/packages/date-fns-jalali/src/date-fns-jalali-utils.ts
+++ b/packages/date-fns-jalali/src/date-fns-jalali-utils.ts
@@ -23,6 +23,7 @@ import getHours from "date-fns-jalali/getHours";
 import getSeconds from "date-fns-jalali/getSeconds";
 import getYear from "date-fns-jalali/getYear";
 import getMonth from "date-fns-jalali/getMonth";
+import getDay from "date-fns-jalali/getDay";
 import getDaysInMonth from "date-fns-jalali/getDaysInMonth";
 import getMinutes from "date-fns-jalali/getMinutes";
 import isAfter from "date-fns-jalali/isAfter";
@@ -279,7 +280,7 @@ export default class DateFnsJalaliUtils implements IUtils<Date> {
     }
 
     return new Date(value);
-  }
+  };
 
   public toJsDate = (value: Date) => {
     return value;
@@ -402,15 +403,18 @@ export default class DateFnsJalaliUtils implements IUtils<Date> {
     let count = 0;
     let current = start;
     const nestedWeeks: Date[][] = [];
-
+    let lastDay = null;
     while (isBefore(current, end)) {
       const weekNumber = Math.floor(count / 7);
       nestedWeeks[weekNumber] = nestedWeeks[weekNumber] || [];
-      nestedWeeks[weekNumber].push(current);
+      const day = getDay(current);
+      if (lastDay !== day) {
+        lastDay = day;
+        nestedWeeks[weekNumber].push(current);
+        count += 1;
+      }
       current = addDays(current, 1);
-      count += 1;
     }
-
     return nestedWeeks;
   };
 

--- a/packages/date-fns/src/date-fns-utils.ts
+++ b/packages/date-fns/src/date-fns-utils.ts
@@ -34,6 +34,7 @@ import dateFnsParse from "date-fns/parse";
 import setHours from "date-fns/setHours";
 import setMinutes from "date-fns/setMinutes";
 import setMonth from "date-fns/setMonth";
+import getDay from "date-fns/getDay";
 import getDaysInMonth from "date-fns/getDaysInMonth";
 import setSeconds from "date-fns/setSeconds";
 import setYear from "date-fns/setYear";
@@ -384,15 +385,18 @@ export default class DateFnsUtils implements IUtils<Date> {
     let count = 0;
     let current = start;
     const nestedWeeks: Date[][] = [];
-
+    let lastDay = null;
     while (isBefore(current, end)) {
       const weekNumber = Math.floor(count / 7);
       nestedWeeks[weekNumber] = nestedWeeks[weekNumber] || [];
-      nestedWeeks[weekNumber].push(current);
+      const day = getDay(current);
+      if (lastDay !== day) {
+        lastDay = day;
+        nestedWeeks[weekNumber].push(current);
+        count += 1;
+      }
       current = addDays(current, 1);
-      count += 1;
     }
-
     return nestedWeeks;
   };
 


### PR DESCRIPTION
for DST, safari has a bug that caused users to see multiple "20th march 2020" for `date-fns` utils or «1399 فروردین 1» for `date-fns-jalali` utils.

related [StackOverflow question][q]


![image](https://user-images.githubusercontent.com/1582954/106354627-7a704b80-6308-11eb-8a3b-e357c32302e4.png)
![1399](https://user-images.githubusercontent.com/1582954/106354633-8956fe00-6308-11eb-819d-fc329a943a04.png)
![2020](https://user-images.githubusercontent.com/1582954/106354635-8a882b00-6308-11eb-847b-ee475860f2ab.png)



[q]: https://stackoverflow.com/questions/14839244/why-is-safari-confused-about-date-getday-for-dst-start-in-sydney-aus-time-zon