### PR TITLE
update date-fns-jalali dependency

### DIFF
--- a/__tests__/date-fns-jalali.test.ts
+++ b/__tests__/date-fns-jalali.test.ts
@@ -336,7 +336,7 @@ describe("DateFnsJalali", () => {
     });
 
     it("DateFnsJalali -- getCurrentLocaleCode: ", () => {
-      expect(utils.getCurrentLocaleCode()).toMatch(/fa-jalali-IR/);
+      expect(utils.getCurrentLocaleCode()).toMatch(/fa-IR/);
     });
 
     it("DateFnsJalali -- toJsDate: ", () => {

--- a/packages/date-fns-jalali/package.json
+++ b/packages/date-fns-jalali/package.json
@@ -43,7 +43,7 @@
     "@date-io/core": "^2.10.7"
   },
   "devDependencies": {
-    "date-fns-jalali": "^2.13.0-0",
+    "date-fns-jalali": "^2.19.0-2",
     "rollup": "^2.0.2",
     "typescript": "^3.7.2"
   },

--- a/packages/date-fns-jalali/src/date-fns-jalali-utils.ts
+++ b/packages/date-fns-jalali/src/date-fns-jalali-utils.ts
@@ -5,15 +5,15 @@ import addDays from "date-fns-jalali/addDays";
 import addWeeks from "date-fns-jalali/addWeeks";
 import addMonths from "date-fns-jalali/addMonths";
 import addYears from "date-fns-jalali/addYears";
-import differenceInYears from "date-fns/differenceInYears";
-import differenceInQuarters from "date-fns/differenceInQuarters";
-import differenceInMonths from "date-fns/differenceInMonths";
-import differenceInWeeks from "date-fns/differenceInWeeks";
-import differenceInDays from "date-fns/differenceInDays";
-import differenceInHours from "date-fns/differenceInHours";
-import differenceInMinutes from "date-fns/differenceInMinutes";
-import differenceInSeconds from "date-fns/differenceInSeconds";
-import differenceInMilliseconds from "date-fns/differenceInMilliseconds";
+import differenceInYears from "date-fns-jalali/differenceInYears";
+import differenceInQuarters from "date-fns-jalali/differenceInQuarters";
+import differenceInMonths from "date-fns-jalali/differenceInMonths";
+import differenceInWeeks from "date-fns-jalali/differenceInWeeks";
+import differenceInDays from "date-fns-jalali/differenceInDays";
+import differenceInHours from "date-fns-jalali/differenceInHours";
+import differenceInMinutes from "date-fns-jalali/differenceInMinutes";
+import differenceInSeconds from "date-fns-jalali/differenceInSeconds";
+import differenceInMilliseconds from "date-fns-jalali/differenceInMilliseconds";
 import eachDayOfInterval from "date-fns-jalali/eachDayOfInterval";
 import endOfDay from "date-fns-jalali/endOfDay";
 import endOfWeek from "date-fns-jalali/endOfWeek";
@@ -48,7 +48,7 @@ import startOfYear from "date-fns-jalali/startOfYear";
 import { IUtils, DateIOFormats, Unit } from "@date-io/core/IUtils";
 import isWithinInterval from "date-fns-jalali/isWithinInterval";
 import longFormatters from "date-fns-jalali/_lib/format/longFormatters";
-import defaultLocale from "date-fns-jalali/locale/fa-jalali-IR";
+import defaultLocale from "date-fns-jalali/locale/fa-IR";
 
 type Locale = typeof defaultLocale;
 
@@ -115,7 +115,7 @@ export default class DateFnsJalaliUtils implements IUtils<Date> {
       return /a/.test(this.locale.formatLong.time());
     }
 
-    // By default date-fns-jalali is using fa-jalali-IR locale with am/pm enabled
+    // By default date-fns-jalali is using fa-IR locale with am/pm enabled
     return true;
   };
 
@@ -139,7 +139,7 @@ export default class DateFnsJalaliUtils implements IUtils<Date> {
   };
 
   public getCurrentLocaleCode = () => {
-    return this.locale?.code || "fa-jalali-IR";
+    return this.locale?.code || "fa-IR";
   };
 
   public addSeconds = (value: Date, count: number) => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2614,10 +2614,10 @@ data-urls@^1.1.0:
     whatwg-mimetype "^2.2.0"
     whatwg-url "^7.0.0"
 
-date-fns-jalali@^2.13.0-0:
-  version "2.13.0-0"
-  resolved "https://registry.yarnpkg.com/date-fns-jalali/-/date-fns-jalali-2.13.0-0.tgz#9e9d9d4a63910654aa72a550c55af9a80e89c060"
-  integrity sha512-yjlI9O18Z6ryGNagryrLO8OQ+3rishM3+A0UOX2UX10cWMn2NTlQcQ+ywTEJvF5IJz0FwX/slt2nCcpyQ/c8gw==
+date-fns-jalali@^2.19.0-2:
+  version "2.19.0-2"
+  resolved "https://registry.yarnpkg.com/date-fns-jalali/-/date-fns-jalali-2.19.0-2.tgz#69d35c6505749e9bce485c0e392604936e20cb2a"
+  integrity sha512-ajgQt3lNFKPN7+mkXpWRJP+NyTVyHRJFVXUV8uc7d9pduVrDn/eeRMT5w1PemXqQRoNqQmuHyKWcrmNPmTRoPA==
 
 date-fns@2.16.1:
   version "2.16.1"


### PR DESCRIPTION
- update `date-fns-jalali@v2.19.0-2`
- using new `fa-IR` locale (introduced in [v2.19.0-2]) instead of `fa-jalali-IR`
- replace `date-fns` imports with `date-fns-jalali`

[v2.19.0-2]: https://github.com/smmoosavi/date-fns-jalali/releases/tag/v2.19.0-2