### PR TITLE
Simplify Luxom adders

### DIFF
--- a/packages/luxon/src/luxon-utils.ts
+++ b/packages/luxon/src/luxon-utils.ts
@@ -106,37 +106,27 @@ export default class LuxonUtils implements IUtils<DateTime> {
   };
 
   public addSeconds = (date: DateTime, count: number) => {
-    return count < 0
-      ? date.minus({ seconds: Math.abs(count) })
-      : date.plus({ seconds: count });
+    return date.plus({ seconds: count });
   };
 
   public addMinutes = (date: DateTime, count: number) => {
-    return count < 0
-      ? date.minus({ minutes: Math.abs(count) })
-      : date.plus({ minutes: count });
+    return date.plus({ minutes: count });
   };
 
   public addHours = (date: DateTime, count: number) => {
-    return count < 0
-      ? date.minus({ hours: Math.abs(count) })
-      : date.plus({ hours: count });
+    return date.plus({ hours: count });
   };
 
   public addDays = (date: DateTime, count: number) => {
-    return count < 0 ? date.minus({ days: Math.abs(count) }) : date.plus({ days: count });
+    return date.plus({ days: count });
   };
 
   public addWeeks = (date: DateTime, count: number) => {
-    return count < 0
-      ? date.minus({ weeks: Math.abs(count) })
-      : date.plus({ weeks: count });
+    return date.plus({ weeks: count });
   };
 
   public addMonths = (date: DateTime, count: number) => {
-    return count < 0
-      ? date.minus({ months: Math.abs(count) })
-      : date.plus({ months: count });
+    return date.plus({ months: count });
   };
 
   public isValid = (value: any) => {


### PR DESCRIPTION
The code for the adders is rather complicated, unnecessary and it will also impact performance on massive calculations.

With simple math, if we add a negative number, it will be subtracted like `10 + -5 = 5`, same goes for Luxon `DateTime.plus`, we can subtract negative values by simple adding them like `DateTime.now().plus({ days: -2 })` and it will subtract 2 days.

Here is a sandbox that demonstrates this https://stackblitz.com/edit/luxon-react-tuw2ft?file=index.js

I made this PR to change all adders from this:

```ts
public addWeeks = (date: DateTime, count: number) => {
  return count < 0
    ? date.minus({ weeks: Math.abs(count) })
    : date.plus({ weeks: count });
};
```

into this:

```ts
public addWeeks = (date: DateTime, count: number) => {
  return date.plus({ weeks: count });
};
```