### PR TITLE
strict parsing a date in dayjs by default

### DIFF
--- a/packages/dayjs/src/dayjs-utils.ts
+++ b/packages/dayjs/src/dayjs-utils.ts
@@ -110,7 +110,7 @@ export default class DayjsUtils<TDate extends Dayjs = Dayjs> implements IUtils<T
       return null;
     }
 
-    return this.dayjs(value, format, this.locale);
+    return this.dayjs(value, format, this.locale, true);
   };
 
   public date = (value?: any) => {


### PR DESCRIPTION
Hi, we found a problem when we using AdapterDayjs with mui date picker in the validation