### PR TITLE
Change `TDate` to an extendable type

### DIFF
--- a/packages/core/IUtils.d.ts
+++ b/packages/core/IUtils.d.ts
@@ -66,9 +66,9 @@ export type Unit =
   | "seconds"
   | "milliseconds";
 
-export interface DateType {}
+export interface ExtendableDateType {}
 
-export interface IUtils<TDate extends DateType> {
+export interface IUtils<TDate extends ExtendableDateType> {
   formats: DateIOFormats<any>;
   locale?: any;
   moment?: any;

--- a/packages/core/IUtils.d.ts
+++ b/packages/core/IUtils.d.ts
@@ -66,7 +66,9 @@ export type Unit =
   | "seconds"
   | "milliseconds";
 
-export interface IUtils<TDate> {
+export interface DateType {}
+
+export interface IUtils<TDate extends DateType> {
   formats: DateIOFormats<any>;
   locale?: any;
   moment?: any;


### PR DESCRIPTION
This change gives you an advantage when developing with date-io.

If you extend the type as shown below in a project using date-io, you can set the Opaque type so that the Date value is not directly referenced.
```ts
declare module '@date-io/core' {
  type Opaque<K, T> = T & { __TYPE__: K };

  interface ExtendableDateType extends Opaque<'DateType', unknown> {}
}
```
This allows me to take advantage of TypeScript more powerfully by not dealing with the `any` type.