### PR TITLE
Fix incorrect date validation from dayjs

### DIFF
--- a/packages/dayjs/src/dayjs-utils.ts
+++ b/packages/dayjs/src/dayjs-utils.ts
@@ -9,7 +9,7 @@ defaultDayjs.extend(localizedFormatPlugin);
 defaultDayjs.extend(isBetweenPlugin);
 
 interface Opts {
-  locale?: string;
+  locale?: ILocale;
   /** Make sure that your dayjs instance extends customParseFormat and advancedFormat */
   instance?: typeof defaultDayjs;
   formats?: Partial<DateIOFormats>;
@@ -59,12 +59,12 @@ export default class DayjsUtils<TDate extends Dayjs = Dayjs> implements IUtils<T
   public rawDayJsInstance: typeof defaultDayjs;
   public lib = "dayjs";
   public dayjs: Constructor<TDate>;
-  public locale?: string;
+  public locale?: ILocale;
   public formats: DateIOFormats;
 
   constructor({ locale, formats, instance }: Opts = {}) {
     this.rawDayJsInstance = instance || defaultDayjs;
-    this.dayjs = withLocale(this.rawDayJsInstance, locale);
+    this.dayjs = withLocale(this.rawDayJsInstance, locale.name);
     this.locale = locale;
 
     this.formats = Object.assign({}, defaultFormats, formats);
@@ -72,11 +72,11 @@ export default class DayjsUtils<TDate extends Dayjs = Dayjs> implements IUtils<T
 
   public is12HourCycleInCurrentLocale = () => {
     /* istanbul ignore next */
-    return /A|a/.test(this.rawDayJsInstance.Ls[this.locale || "en"]?.formats?.LT);
+    return /A|a/.test(this.rawDayJsInstance.Ls[this.locale.name || "en"]?.formats?.LT);
   };
 
   public getCurrentLocaleCode = () => {
-    return this.locale || "en";
+    return this.locale.name || "en";
   };
 
   public getFormatHelperText = (format: string) => {
@@ -88,7 +88,9 @@ export default class DayjsUtils<TDate extends Dayjs = Dayjs> implements IUtils<T
         var firstCharacter = token[0];
         if (firstCharacter === "L") {
           /* istanbul ignore next */
-          return this.rawDayJsInstance.Ls[this.locale || "en"]?.formats[token] ?? token;
+          return (
+            this.rawDayJsInstance.Ls[this.locale.name || "en"]?.formats[token] ?? token
+          );
         }
         return token;
       })
@@ -110,7 +112,7 @@ export default class DayjsUtils<TDate extends Dayjs = Dayjs> implements IUtils<T
       return null;
     }
 
-    return this.dayjs(value, format, this.locale);
+    return this.dayjs(value, format, this.locale?.name, true);
   };
 
   public date = (value?: any) => {

--- a/packages/dayjs/src/dayjs-utils.ts
+++ b/packages/dayjs/src/dayjs-utils.ts
@@ -9,7 +9,7 @@ defaultDayjs.extend(localizedFormatPlugin);
 defaultDayjs.extend(isBetweenPlugin);
 
 interface Opts {
-  locale?: ILocale;
+  locale?: string;
   /** Make sure that your dayjs instance extends customParseFormat and advancedFormat */
   instance?: typeof defaultDayjs;
   formats?: Partial<DateIOFormats>;
@@ -57,40 +57,42 @@ const defaultFormats: DateIOFormats = {
 
 export default class DayjsUtils<TDate extends Dayjs = Dayjs> implements IUtils<TDate> {
   public rawDayJsInstance: typeof defaultDayjs;
+
   public lib = "dayjs";
+
   public dayjs: Constructor<TDate>;
-  public locale?: ILocale;
+
+  public locale?: string;
+
   public formats: DateIOFormats;
 
   constructor({ locale, formats, instance }: Opts = {}) {
     this.rawDayJsInstance = instance || defaultDayjs;
-    this.dayjs = withLocale(this.rawDayJsInstance, locale.name);
+    this.dayjs = withLocale(this.rawDayJsInstance, locale);
     this.locale = locale;
 
-    this.formats = Object.assign({}, defaultFormats, formats);
+    this.formats = { ...defaultFormats, ...formats };
   }
 
   public is12HourCycleInCurrentLocale = () => {
     /* istanbul ignore next */
-    return /A|a/.test(this.rawDayJsInstance.Ls[this.locale.name || "en"]?.formats?.LT);
+    return /A|a/.test(this.rawDayJsInstance.Ls[this.locale || "en"]?.formats?.LT);
   };
 
   public getCurrentLocaleCode = () => {
-    return this.locale.name || "en";
+    return this.locale || "en";
   };
 
   public getFormatHelperText = (format: string) => {
     // @see https://github.com/iamkun/dayjs/blob/dev/src/plugin/localizedFormat/index.js
-    var localFormattingTokens = /(\[[^\[]*\])|(\\)?(LTS|LT|LL?L?L?)|./g;
+    const localFormattingTokens = /(\[[^\[]*\])|(\\)?(LTS|LT|LL?L?L?)|./g;
     return format
       .match(localFormattingTokens)
       .map((token) => {
-        var firstCharacter = token[0];
+        const firstCharacter = token[0];
         if (firstCharacter === "L") {
           /* istanbul ignore next */
-          return (
-            this.rawDayJsInstance.Ls[this.locale.name || "en"]?.formats[token] ?? token
-          );
+          return this.rawDayJsInstance.Ls[this.locale || "en"]?.formats[token] ?? token;
         }
         return token;
       })
@@ -112,7 +114,7 @@ export default class DayjsUtils<TDate extends Dayjs = Dayjs> implements IUtils<T
       return null;
     }
 
-    return this.dayjs(value, format, this.locale?.name, true);
+    return this.dayjs(value, format, this.locale, true);
   };
 
   public date = (value?: any) => {

--- a/packages/dayjs/src/dayjs-utils.ts
+++ b/packages/dayjs/src/dayjs-utils.ts
@@ -57,13 +57,9 @@ const defaultFormats: DateIOFormats = {
 
 export default class DayjsUtils<TDate extends Dayjs = Dayjs> implements IUtils<TDate> {
   public rawDayJsInstance: typeof defaultDayjs;
-
   public lib = "dayjs";
-
   public dayjs: Constructor<TDate>;
-
   public locale?: string;
-
   public formats: DateIOFormats;
 
   constructor({ locale, formats, instance }: Opts = {}) {
@@ -71,7 +67,7 @@ export default class DayjsUtils<TDate extends Dayjs = Dayjs> implements IUtils<T
     this.dayjs = withLocale(this.rawDayJsInstance, locale);
     this.locale = locale;
 
-    this.formats = { ...defaultFormats, ...formats };
+    this.formats = Object.assign({}, defaultFormats, formats);
   }
 
   public is12HourCycleInCurrentLocale = () => {
@@ -85,11 +81,11 @@ export default class DayjsUtils<TDate extends Dayjs = Dayjs> implements IUtils<T
 
   public getFormatHelperText = (format: string) => {
     // @see https://github.com/iamkun/dayjs/blob/dev/src/plugin/localizedFormat/index.js
-    const localFormattingTokens = /(\[[^\[]*\])|(\\)?(LTS|LT|LL?L?L?)|./g;
+    var localFormattingTokens = /(\[[^\[]*\])|(\\)?(LTS|LT|LL?L?L?)|./g;
     return format
       .match(localFormattingTokens)
       .map((token) => {
-        const firstCharacter = token[0];
+        var firstCharacter = token[0];
         if (firstCharacter === "L") {
           /* istanbul ignore next */
           return this.rawDayJsInstance.Ls[this.locale || "en"]?.formats[token] ?? token;


### PR DESCRIPTION
## What is the problem?
As shown at https://github.com/mui/material-ui/issues/30886 and https://github.com/mui/material-ui/issues/29838, there is a problem validating dates using dayjs.
I noticed that the [parse](https://github.com/dmtrKovalenko/date-io/blob/dc9a2ba540f6032fab5d40d57ba646d8d25e33ba/packages/dayjs/src/dayjs-utils.ts#L108) function uses dayjs parse without strict format, causing dayjs to convert any date, even if incorrect, e.g. "99/99/2000" to a correct date, and due to this, all other functions used later ([date](https://github.com/dmtrKovalenko/date-io/blob/dc9a2ba540f6032fab5d40d57ba646d8d25e33ba/packages/dayjs/src/dayjs-utils.ts#L116), [isValid](https://github.com/dmtrKovalenko/date-io/blob/dc9a2ba540f6032fab5d40d57ba646d8d25e33ba/packages/dayjs/src/dayjs-utils.ts#L128), etc) do not have ability to validade dates, as they will always receive a supposedly valid date.

This issue is the same as #599

## What did I do?
* I changed the type of the `local` [here](https://github.com/dmtrKovalenko/date-io/blob/dc9a2ba540f6032fab5d40d57ba646d8d25e33ba/packages/dayjs/src/dayjs-utils.ts#L12) and [here](https://github.com/dmtrKovalenko/date-io/blob/dc9a2ba540f6032fab5d40d57ba646d8d25e33ba/packages/dayjs/src/dayjs-utils.ts#L62) from string to `ILocale`, because it's the type passed by dayjs
* Due to the previous change, I changed the places where `this.locale` was called as string to `this.locale?.name`, because it's the equivalent
* I changed [parse](https://github.com/dmtrKovalenko/date-io/blob/dc9a2ba540f6032fab5d40d57ba646d8d25e33ba/packages/dayjs/src/dayjs-utils.ts#L108) function return from `this.dayjs(value, format, this.locale)` to `this.dayjs(value, format, this.locale?.name, true)`, enabling strict mode.

## Note
I'm working with material-ui DatePickers, and with my changes, pickers work perfectly
