### PR TITLE
feat: New methods `startOfYear` and `endOfYear`

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,8 @@ export interface IUtils<TDate> {
 
   isWithinRange(value: TDate, range: [TDate, TDate]): boolean;
 
+  startOfYear(value: TDate): TDate;
+  endOfYear(value: TDate): TDate;
   startOfMonth(value: TDate): TDate;
   endOfMonth(value: TDate): TDate;
   startOfWeek(value: TDate): TDate;

--- a/__tests__/calculations.test.ts
+++ b/__tests__/calculations.test.ts
@@ -66,6 +66,18 @@ describe("DateTime calculations", () => {
     );
   });
 
+  utilsTest("startOfYear", (date, utils, lib) => {
+    expect(utils.formatByString(utils.startOfYear(date), formats.dateTime[lib])).toBe(
+      "2018-01-01 00:00"
+    );
+  });
+
+  utilsTest("endOfYear", (date, utils, lib) => {
+    expect(utils.formatByString(utils.endOfYear(date), formats.dateTime[lib])).toBe(
+      "2018-12-31 23:59"
+    );
+  });
+
   utilsTest("startOfMonth", (date, utils, lib) => {
     expect(utils.formatByString(utils.startOfMonth(date), formats.dateTime[lib])).toBe(
       "2018-10-01 00:00"

--- a/__tests__/date-fns-jalali.test.ts
+++ b/__tests__/date-fns-jalali.test.ts
@@ -74,6 +74,18 @@ describe("DateFnsJalali", () => {
       );
     });
 
+    it("DateFnsJalali -- startOfYear", () => {
+      expect(utils.formatByString(utils.startOfYear(date), dateTimeFormat)).toBe(
+        "1397/01/01 00:00"
+      );
+    });
+
+    it("DateFnsJalali -- endOfYear", () => {
+      expect(utils.formatByString(utils.endOfYear(date), dateTimeFormat)).toBe(
+        "1397/12/29 23:59"
+      );
+    });
+
     it("DateFnsJalali -- startOfMonth", () => {
       expect(utils.formatByString(utils.startOfMonth(date), dateTimeFormat)).toBe(
         "1397/08/01 00:00"

--- a/__tests__/hijri.test.ts
+++ b/__tests__/hijri.test.ts
@@ -46,6 +46,22 @@ describe("Hijri", () => {
     expect(hijriiUtils.getWeekdays()).toEqual(["ح", "ن", "ث", "ر", "خ", "ج", "س"]);
   });
 
+  it("Hijri -- endOfYear", () => {
+    const date = hijriiUtils.date(TEST_TIMESTAMP);
+
+    expect(hijriiUtils.endOfYear(date).toISOString()).toEqual(
+      "2019-08-30T23:59:59.999Z"
+    );
+  });
+
+  it("Hijri -- startOfYear", () => {
+    const date = hijriiUtils.date(TEST_TIMESTAMP);
+
+    expect(hijriiUtils.startOfYear(date).toISOString()).toEqual(
+      "2018-09-11T00:00:00.000Z"
+    );
+  });
+
   it("Hijri -- endOfMonth", () => {
     const date = hijriiUtils.date(TEST_TIMESTAMP);
 

--- a/__tests__/jalaali.test.ts
+++ b/__tests__/jalaali.test.ts
@@ -53,7 +53,7 @@ describe("Jalaali", () => {
     const date = jalaaliUtils.date(TEST_TIMESTAMP);
 
     expect(jalaaliUtils.endOfYear(date).toISOString()).toEqual(
-      "2018-11-21T23:59:59.999Z"
+      "2018-03-20T23:59:59.999Z"
     );
   });
 
@@ -61,7 +61,7 @@ describe("Jalaali", () => {
     const date = jalaaliUtils.date(TEST_TIMESTAMP);
 
     expect(jalaaliUtils.startOfYear(date).toISOString()).toEqual(
-      "2018-10-23T00:00:00.000Z"
+      "2018-03-21T00:00:00.000Z"
     );
   });
 

--- a/__tests__/jalaali.test.ts
+++ b/__tests__/jalaali.test.ts
@@ -53,7 +53,7 @@ describe("Jalaali", () => {
     const date = jalaaliUtils.date(TEST_TIMESTAMP);
 
     expect(jalaaliUtils.endOfYear(date).toISOString()).toEqual(
-      "2018-03-20T23:59:59.999Z"
+      "2019-03-20T23:59:59.999Z"
     );
   });
 

--- a/__tests__/jalaali.test.ts
+++ b/__tests__/jalaali.test.ts
@@ -49,6 +49,22 @@ describe("Jalaali", () => {
     expect(jalaaliUtils.getWeekdays()).toEqual(["ش", "ی", "د", "س", "چ", "پ", "ج"]);
   });
 
+  it("Jalaali -- endOfYear", () => {
+    const date = jalaaliUtils.date(TEST_TIMESTAMP);
+
+    expect(jalaaliUtils.endOfYear(date).toISOString()).toEqual(
+      "2018-11-21T23:59:59.999Z"
+    );
+  });
+
+  it("Jalaali -- startOfYear", () => {
+    const date = jalaaliUtils.date(TEST_TIMESTAMP);
+
+    expect(jalaaliUtils.startOfYear(date).toISOString()).toEqual(
+      "2018-10-23T00:00:00.000Z"
+    );
+  });
+
   it("Jalaali -- endOfMonth", () => {
     const date = jalaaliUtils.date(TEST_TIMESTAMP);
 

--- a/__tests__/local-date-calculations.test.ts
+++ b/__tests__/local-date-calculations.test.ts
@@ -49,6 +49,18 @@ describe("DateTime calculations", () => {
     );
   });
 
+  localDateutilsTest("startOfYear", (date, utils, lib) => {
+    expect(utils.formatByString(utils.startOfYear(date), formats.dateTime[lib])).toBe(
+      "2018-01-01 00:00"
+    );
+  });
+
+  localDateutilsTest("endOfYear", (date, utils, lib) => {
+    expect(utils.formatByString(utils.endOfYear(date), formats.dateTime[lib])).toBe(
+      "2018-12-31 23:59"
+    );
+  });
+
   localDateutilsTest("startOfMonth", (date, utils, lib) => {
     expect(utils.formatByString(utils.startOfMonth(date), formats.dateTime[lib])).toBe(
       "2018-10-01 00:00"

--- a/packages/core/IUtils.d.ts
+++ b/packages/core/IUtils.d.ts
@@ -109,6 +109,8 @@ export interface IUtils<TDate extends ExtendableDateType> {
 
   isWithinRange(value: TDate, range: [TDate, TDate]): boolean;
 
+  startOfYear(value: TDate): TDate;
+  endOfYear(value: TDate): TDate;
   startOfMonth(value: TDate): TDate;
   endOfMonth(value: TDate): TDate;
   startOfWeek(value: TDate): TDate;

--- a/packages/core/dev-utils.js
+++ b/packages/core/dev-utils.js
@@ -14,7 +14,7 @@ exports.createRollupConfig = (typescript) => {
       output: {
         file: `build/index.esm.js`,
         format: "esm",
-        exports: "auto"
+        exports: "auto",
       },
       plugins: [nodeResolve({ extensions }), typescriptPlugin({ typescript })],
     },
@@ -24,7 +24,7 @@ exports.createRollupConfig = (typescript) => {
       output: {
         file: `build/index.js`,
         format: "cjs",
-        exports: "auto"
+        exports: "auto",
       },
       plugins: [nodeResolve({ extensions }), typescriptPlugin({ typescript })],
     },

--- a/packages/date-fns-jalali/src/date-fns-jalali-utils.ts
+++ b/packages/date-fns-jalali/src/date-fns-jalali-utils.ts
@@ -248,6 +248,14 @@ export default class DateFnsJalaliUtils implements IUtils<Date> {
     return isSameHour(value, comparing);
   };
 
+  public startOfYear = (value: Date) => {
+    return startOfYear(value);
+  };
+
+  public endOfYear = (value: Date) => {
+    return endOfYear(value);
+  };
+
   public startOfMonth = (value: Date) => {
     return startOfMonth(value);
   };

--- a/packages/date-fns/src/date-fns-utils.ts
+++ b/packages/date-fns/src/date-fns-utils.ts
@@ -241,6 +241,14 @@ export default class DateFnsUtils implements IUtils<Date> {
     return isSameHour(value, comparing);
   };
 
+  public startOfYear = (value: Date) => {
+    return startOfYear(value);
+  };
+
+  public endOfYear = (value: Date) => {
+    return endOfYear(value);
+  };
+
   public startOfMonth = (value: Date) => {
     return startOfMonth(value);
   };

--- a/packages/dayjs/src/dayjs-utils.ts
+++ b/packages/dayjs/src/dayjs-utils.ts
@@ -273,6 +273,14 @@ export default class DayjsUtils<TDate extends Dayjs = Dayjs> implements IUtils<T
     return ampm === "am" ? "AM" : "PM";
   };
 
+  public startOfYear = (date: Dayjs) => {
+    return date.clone().startOf("year") as TDate;
+  };
+
+  public endOfYear = (date: Dayjs) => {
+    return date.clone().endOf("year") as TDate;
+  };
+
   public startOfMonth = (date: Dayjs) => {
     return date.clone().startOf("month") as TDate;
   };

--- a/packages/dayjs/src/dayjs-utils.ts
+++ b/packages/dayjs/src/dayjs-utils.ts
@@ -274,11 +274,11 @@ export default class DayjsUtils<TDate extends Dayjs = Dayjs> implements IUtils<T
   };
 
   public startOfYear = (date: Dayjs) => {
-    return date.clone().startOf("year") as TDate;
+    return date.startOf("year") as TDate;
   };
 
   public endOfYear = (date: Dayjs) => {
-    return date.clone().endOf("year") as TDate;
+    return date.endOf("year") as TDate;
   };
 
   public startOfMonth = (date: Dayjs) => {

--- a/packages/hijri/src/hijri-utils.ts
+++ b/packages/hijri/src/hijri-utils.ts
@@ -104,6 +104,14 @@ export default class MomentUtils extends DefaultMomentUtils {
     return date.daysInMonth();
   };
 
+  public startOfYear = (date: Moment) => {
+    return date.clone().startOf("iYear");
+  };
+
+  public endOfYear = (date: Moment) => {
+    return date.clone().endOf("iYear");
+  };
+
   public startOfMonth = (date: Moment) => {
     return date.clone().startOf("iMonth");
   };

--- a/packages/jalaali/src/jalaali-utils.ts
+++ b/packages/jalaali/src/jalaali-utils.ts
@@ -103,6 +103,14 @@ export default class MomentUtils extends DefaultMomentUtils {
     return date.daysInMonth();
   };
 
+  public startOfYear = (date: Moment) => {
+    return date.clone().startOf("jYear");
+  };
+
+  public endOfYear = (date: Moment) => {
+    return date.clone().endOf("jYear");
+  };
+
   public startOfMonth = (date: Moment) => {
     return date.clone().startOf("jMonth");
   };

--- a/packages/js-joda/src/js-joda-utils.ts
+++ b/packages/js-joda/src/js-joda-utils.ts
@@ -301,6 +301,14 @@ export default class JsJodaUtils implements IUtils<Temporal> {
     return datedate.isBefore(valuedate);
   }
 
+  startOfYear(date: Temporal) {
+    return Year.from(date).atMonth(1).atDay(1).atStartOfDay();
+  }
+
+  endOfYear(date: Temporal) {
+    return Year.from(date).atMonth(12).atEndOfMonth().atTime(LocalTime.MAX);
+  }
+
   startOfMonth(date: Temporal) {
     return YearMonth.from(date).atDay(1).atStartOfDay();
   }

--- a/packages/js-joda/type/index.d.ts
+++ b/packages/js-joda/type/index.d.ts
@@ -1,5 +1,5 @@
 declare module "@date-io/type" {
-  import {Temporal} from "@js-joda/core";
+  import { Temporal } from "@js-joda/core";
 
   export type DateType = Temporal;
 }

--- a/packages/luxon/src/luxon-utils.ts
+++ b/packages/luxon/src/luxon-utils.ts
@@ -282,6 +282,14 @@ export default class LuxonUtils implements IUtils<DateTime> {
     });
   };
 
+  public startOfYear = (value: DateTime) => {
+    return value.startOf("year");
+  };
+
+  public endOfYear = (value: DateTime) => {
+    return value.endOf("year");
+  };
+
   public startOfMonth = (value: DateTime) => {
     return value.startOf("month");
   };

--- a/packages/moment/src/moment-utils.ts
+++ b/packages/moment/src/moment-utils.ts
@@ -267,6 +267,14 @@ export default class MomentUtils implements IUtils<defaultMoment.Moment> {
     return ampm === "am" ? "AM" : "PM"; // fallback for de, ru, ...etc
   };
 
+  public startOfYear = (date: Moment) => {
+    return date.clone().startOf("year");
+  };
+
+  public endOfYear = (date: Moment) => {
+    return date.clone().endOf("year");
+  };
+
   public startOfMonth = (date: Moment) => {
     return date.clone().startOf("month");
   };


### PR DESCRIPTION
## Goal

Add two new methods `startOfYear` and `endOfYear` following the model of the other `startOfXXX` / `endOfXXX`.

They will be used on `@mui/x-date-pickers` to improve the behavior when we select a year but the current date is disabled.

For instance if we are on 2018-01-01 and all days are enabled except 2019-01-01 to 2019-01-04.
If we change the year from 2018 to 2019, we expect the new date to be 2019-01-04.
But right now, it will be 2018-12-31 because we don't limit to the current year when looking for the closest enabled date.

This new method will allow to easily create the minDate / maxDate when looking for the closest valid date.

## Side note

With @alexfauquette we now maintain the date pickers from MUI.
I will probably have other methods to add (`getDate` to get the date number in the month would be nice for instance).
If you want to organize our work differently between the adapters and the packages we are available to discuss it.