### PR TITLE
do not error when second argument does not have a time part

### DIFF
--- a/packages/js-joda/src/js-joda-utils.ts
+++ b/packages/js-joda/src/js-joda-utils.ts
@@ -414,7 +414,9 @@ export default class JsJodaUtils implements IUtils<Temporal> {
   }
 
   mergeDateAndTime(date: Temporal, time: Temporal): Temporal {
-    return LocalDate.from(date).atTime(LocalTime.from(time));
+    var qtime = time.query(TemporalQueries.localTime());
+    if (qtime == null) return date;
+    else return LocalDate.from(date).atTime(LocalTime.from(time));
   }
 
   getWeekdays(): string[] {


### PR DESCRIPTION
mergeDateAndTime will error out if `time` does not have time components. Most consumers of date-io are unfamiliar that a time library could protect against an issue like that. For instance https://mui.com/x/react-date-pickers/date-picker/ will call mergeDateAndTime when just dealing with dates. This patch will make date-io work more like the other date libraries without a strong type system. 