### PR TITLE
Add peer dependency support for Luxon 3

### DIFF
--- a/packages/luxon/package.json
+++ b/packages/luxon/package.json
@@ -9,7 +9,7 @@
     "build": "rollup -c && tsc -p tsconfig.declaration.json"
   },
   "peerDependencies": {
-    "luxon": "^1.21.3 || ^2.x"
+    "luxon": "^1.21.3 || ^2.x || ^3.x"
   },
   "peerDependenciesMeta": {
     "luxon": {
@@ -21,7 +21,7 @@
   },
   "devDependencies": {
     "@types/luxon": "^1.27.1",
-    "luxon": "^2.0.2",
+    "luxon": "^3.0.4",
     "rollup": "^2.0.2",
     "typescript": "^3.7.2"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -5002,10 +5002,10 @@ lru-cache@^5.1.1:
   dependencies:
     yallist "^3.0.2"
 
-luxon@^2.0.2:
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/luxon/-/luxon-2.3.0.tgz#bf16a7e642513c2a20a6230a6a41b0ab446d0045"
-  integrity sha512-gv6jZCV+gGIrVKhO90yrsn8qXPKD8HYZJtrUDSfEbow8Tkw84T9OnCyJhWvnJIaIF/tBuiAjZuQHUt1LddX2mg==
+luxon@^3.0.4:
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/luxon/-/luxon-3.0.4.tgz#d179e4e9f05e092241e7044f64aaa54796b03929"
+  integrity sha512-aV48rGUwP/Vydn8HT+5cdr26YYQiUZ42NM6ToMoaGKwYfWbfLeRkEu1wXWMHBZT6+KyLfcbbtVcoQFCbbPjKlw==
 
 macos-release@^2.2.0:
   version "2.3.0"


### PR DESCRIPTION
Luxon 3.x has a very minor [breaking change](https://moment.github.io/luxon/#/upgrading) that doesn't affect the shape of the API, so it should be safe for date-io to support it.