### PR TITLE
moment: use this.locale when specified

### DIFF
--- a/packages/moment/src/moment-utils.ts
+++ b/packages/moment/src/moment-utils.ts
@@ -52,7 +52,9 @@ export default class MomentUtils implements IUtils<defaultMoment.Moment> {
   }
 
   public is12HourCycleInCurrentLocale = () => {
-    return /A|a/.test(this.moment().localeData().longDateFormat("LT"));
+    return /A|a/.test(
+      this.moment.localeData(this.getCurrentLocaleCode()).longDateFormat("LT")
+    );
   };
 
   public getFormatHelperText = (format: string) => {
@@ -63,7 +65,9 @@ export default class MomentUtils implements IUtils<defaultMoment.Moment> {
       .map((token) => {
         const firstCharacter = token[0];
         if (firstCharacter === "L" || firstCharacter === ";") {
-          return this.moment.localeData().longDateFormat(token as LongDateFormatKey);
+          return this.moment
+            .localeData(this.getCurrentLocaleCode())
+            .longDateFormat(token as LongDateFormatKey);
         }
 
         return token;
@@ -267,7 +271,9 @@ export default class MomentUtils implements IUtils<defaultMoment.Moment> {
   public getMeridiemText = (ampm: "am" | "pm") => {
     if (this.is12HourCycleInCurrentLocale()) {
       // AM/PM translation only possible in those who have 12 hour cycle in locale.
-      return this.moment.localeData().meridiem(ampm === "am" ? 0 : 13, 0, false);
+      return this.moment
+        .localeData(this.getCurrentLocaleCode())
+        .meridiem(ampm === "am" ? 0 : 13, 0, false);
     }
 
     return ampm === "am" ? "AM" : "PM"; // fallback for de, ru, ...etc


### PR DESCRIPTION
Related to https://github.com/mui/mui-x/pull/6547

When importing multiple locales, the default moment local is the last one.

The `adapter.getFormatHelperText()` will apply the default moment locale instead of the one provided to the adapter.

Fixed by
```diff
-this.moment.localeData()
+this.moment.localeData(this.getCurrentLocaleCode())
```