### PR TITLE
fix: update jalaali-utils getDaysInMonth and add missing overrides

### DIFF
--- a/__tests__/jalaali.test.ts
+++ b/__tests__/jalaali.test.ts
@@ -43,7 +43,7 @@ describe("Jalaali", () => {
   it("Should proper work with jalaali days in month", () => {
     const date = jalaaliUtils.date(TEST_TIMESTAMP);
 
-    expect(jalaaliUtils.getDaysInMonth(date)).toBe(31);
+    expect(jalaaliUtils.getDaysInMonth(date)).toBe(30);
   });
 
   it("Should properly render meridiem", () => {
@@ -58,9 +58,7 @@ describe("Jalaali", () => {
   it("Jalaali -- getYear", () => {
     const date = jalaaliUtils.date(TEST_TIMESTAMP);
 
-    expect(jalaaliUtils.getYear(date)).toEqual(
-      1397
-    );
+    expect(jalaaliUtils.getYear(date)).toEqual(1397);
   });
 
   it("Jalaali -- setYear", () => {
@@ -74,9 +72,7 @@ describe("Jalaali", () => {
   it("Jalaali -- getDate", () => {
     const date = jalaaliUtils.date(TEST_TIMESTAMP);
 
-    expect(jalaaliUtils.getDate(date)).toEqual(
-      8
-    );
+    expect(jalaaliUtils.getDate(date)).toEqual(8);
   });
 
   it("Jalaali -- setDate", () => {
@@ -90,9 +86,7 @@ describe("Jalaali", () => {
   it("Jalaali -- getYear", () => {
     const date = jalaaliUtils.date(TEST_TIMESTAMP);
 
-    expect(jalaaliUtils.getYear(date)).toEqual(
-      1397
-    );
+    expect(jalaaliUtils.getYear(date)).toEqual(1397);
   });
 
   it("Jalaali -- endOfYear", () => {

--- a/packages/jalaali/src/jalaali-utils.ts
+++ b/packages/jalaali/src/jalaali-utils.ts
@@ -112,7 +112,7 @@ export default class MomentUtils extends DefaultMomentUtils {
   };
 
   public getDaysInMonth = (date: Moment) => {
-    return date.daysInMonth();
+    return this.moment.jDaysInMonth(date.jYear(), date.jMonth());
   };
 
   public startOfYear = (date: Moment) => {
@@ -217,5 +217,40 @@ export default class MomentUtils extends DefaultMomentUtils {
     }
 
     return years;
+  };
+  public addMonths = (date: Moment, count: number) => {
+    return count < 0
+      ? date.clone().subtract(Math.abs(count), "jMonth")
+      : date.clone().add(count, "jMonth");
+  };
+
+  public addYears = (date: Moment, count: number) => {
+    return count < 0
+      ? date.clone().subtract(Math.abs(count), "jYear")
+      : date.clone().add(count, "jYear");
+  };
+
+  public isSameMonth = (date: Moment, comparing: Moment) => {
+    return date.jYear() === comparing.jYear() && date.jMonth() === comparing.jMonth();
+  };
+
+  public isSameYear = (date: Moment, comparing: Moment) => {
+    return date.jYear() === comparing.jYear();
+  };
+
+  public setMonth = (date: Moment, count: number) => {
+    return date.clone().jMonth(count);
+  };
+
+  public getMonthArray = (date: Moment) => {
+    const firstMonth = date.clone().startOf("jYear");
+    const monthArray = [firstMonth];
+
+    while (monthArray.length < 12) {
+      const prevMonth = monthArray[monthArray.length - 1];
+      monthArray.push(this.getNextMonth(prevMonth));
+    }
+
+    return monthArray;
   };
 }

--- a/packages/jalaali/src/jalaali-utils.ts
+++ b/packages/jalaali/src/jalaali-utils.ts
@@ -107,10 +107,6 @@ export default class MomentUtils extends DefaultMomentUtils {
     return date.jMonth();
   };
 
-  public setMonth = (date: Moment, month: number) => {
-    return date.clone().jMonth(month);
-  };
-
   public getDaysInMonth = (date: Moment) => {
     return this.moment.jDaysInMonth(date.jYear(), date.jMonth());
   };


### PR DESCRIPTION
current adapter in `jalaali-utils` returns Gregorian number of days in month, leading to problems with [MUI Datepickers](https://mui.com/x/react-date-pickers) about rendering months.

This pull requests fixes the issue and adds missing overrides in jalaali adapter.
 