### PR TITLE
feat(luxon): Use `DateTime.isDateTime` instead of `instanceof`

### DIFF
--- a/packages/luxon/src/luxon-utils.ts
+++ b/packages/luxon/src/luxon-utils.ts
@@ -57,7 +57,7 @@ export default class LuxonUtils implements IUtils<DateTime> {
       return DateTime.fromJSDate(new Date(value), { locale: this.locale });
     }
 
-    if (value instanceof DateTime) {
+    if (DateTime.isDateTime(value)) {
       return value;
     }
 
@@ -134,7 +134,7 @@ export default class LuxonUtils implements IUtils<DateTime> {
   };
 
   public isValid = (value: any) => {
-    if (value instanceof DateTime) {
+    if (DateTime.isDateTime(value)) {
       return value.isValid;
     }
 


### PR DESCRIPTION
The usage of `DateTime.isDateTime` should be more stable without breaking existing behavior. It also satisfies the current version constraints of luxon (added in 1.6.0).