### PR TITLE
refactor: uniquely name declared modules

### DIFF
--- a/packages/date-fns-jalali/type/index.d.ts
+++ b/packages/date-fns-jalali/type/index.d.ts
@@ -1,3 +1,3 @@
-declare module "@date-io/type" {
+declare module "@date-io/date-fns-jalali/type" {
   export type DateType = Date;
 }

--- a/packages/date-fns/type/index.d.ts
+++ b/packages/date-fns/type/index.d.ts
@@ -1,3 +1,3 @@
-declare module "@date-io/type" {
+declare module "@date-io/date-fns/type" {
   export type DateType = Date;
 }

--- a/packages/dayjs/type/index.d.ts
+++ b/packages/dayjs/type/index.d.ts
@@ -1,4 +1,4 @@
-declare module "@date-io/type" {
+declare module "@date-io/dayjs/type" {
   import { Dayjs } from "dayjs";
 
   export type DateType = Dayjs;

--- a/packages/hijri/type/index.d.ts
+++ b/packages/hijri/type/index.d.ts
@@ -1,4 +1,4 @@
-declare module "@date-io/type" {
+declare module "@date-io/moment-hijri/type" {
   import { Moment } from "moment-hijri";
 
   export type DateType = Moment;

--- a/packages/jalaali/type/index.d.ts
+++ b/packages/jalaali/type/index.d.ts
@@ -1,4 +1,4 @@
-declare module "@date-io/type" {
+declare module "@date-io/moment-jalaali/type" {
   import { Moment } from "moment-jalaali";
 
   export type DateType = Moment;

--- a/packages/js-joda/type/index.d.ts
+++ b/packages/js-joda/type/index.d.ts
@@ -1,4 +1,4 @@
-declare module "@date-io/type" {
+declare module "@date-io/@js-joda/type" {
   import { Temporal } from "@js-joda/core";
 
   export type DateType = Temporal;

--- a/packages/luxon/type/index.d.ts
+++ b/packages/luxon/type/index.d.ts
@@ -1,4 +1,4 @@
-declare module "@date-io/type" {
+declare module "@date-io/luxon/type" {
   import { DateTime } from "luxon";
 
   export type DateType = DateTime;

--- a/packages/moment/type/index.d.ts
+++ b/packages/moment/type/index.d.ts
@@ -1,4 +1,4 @@
-declare module "@date-io/type" {
+declare module "@date-io/moment/type" {
   import { Moment } from "moment";
 
   export type DateType = Moment;


### PR DESCRIPTION
Rename declared adapter modules to have unique name avoiding possible type collisions when multiple `@date-io` adapters are used in a single repo.
Should avoid issues like #52.
Currently being tested in https://github.com/mui/mui-x/pull/7808 with `patch-package`.

**Warning:** It should be considered as a breaking change (unless I'm misunderstanding something), as discussed here: https://github.com/dmtrKovalenko/date-io/issues/52#issuecomment-1414044630