### PR TITLE
fix: adds tslib deps to fix the error of it not being found when impo…

### DIFF
--- a/packages/hijri/package.json
+++ b/packages/hijri/package.json
@@ -6,7 +6,8 @@
   "module": "build/index.esm.js",
   "typings": "build/index.d.ts",
   "peerDependencies": {
-    "moment-hijri": "^2.1.2"
+    "moment-hijri": "^2.1.2",
+    "tslib": "^2.5.0"
   },
   "peerDependenciesMeta": {
     "moment-hijri": {

--- a/packages/jalaali/package.json
+++ b/packages/jalaali/package.json
@@ -6,7 +6,8 @@
   "module": "build/index.esm.js",
   "typings": "build/index.d.ts",
   "peerDependencies": {
-    "moment-jalaali": "^0.7.4 || ^0.8.0 || ^0.9.0"
+    "moment-jalaali": "^0.7.4 || ^0.8.0 || ^0.9.0",
+    "tslib": "^2.5.0"
   },
   "peerDependenciesMeta": {
     "moment-jalaali": {


### PR DESCRIPTION
…rting date-io libs

Resolves #248 

Just want to make sure that I should be adding this dependency to the root and not within the `hijri` package where the error has been occurring in this [CodeSandbox demo](https://codesandbox.io/s/gz5zyp?file=/demo.tsx)?

On an additional note I share the sentiment from #641 that perhaps it might be better for some of the deps such as `typescript` and `ts-jest` to be moved into devDependencies eventually which means that `tslib` can also be moved into there as well. But hopefully this PR can fix the issue at hand for now