### PR TITLE
refactor: change build to target `ES6`

### DIFF
--- a/packages/core/dev-utils.js
+++ b/packages/core/dev-utils.js
@@ -16,7 +16,7 @@ exports.createRollupConfig = (typescript) => {
         format: "esm",
         exports: "auto",
       },
-      plugins: [nodeResolve({ extensions }), typescriptPlugin({ typescript })],
+      plugins: [nodeResolve({ extensions }), typescriptPlugin({ typescript, target: 'ES6', })],
     },
     {
       external,
@@ -26,7 +26,7 @@ exports.createRollupConfig = (typescript) => {
         format: "cjs",
         exports: "auto",
       },
-      plugins: [nodeResolve({ extensions }), typescriptPlugin({ typescript })],
+      plugins: [nodeResolve({ extensions }), typescriptPlugin({ typescript, target: 'ES6', })],
     },
   ];
 };


### PR DESCRIPTION
Fixes #248 

As discussed in the issue, `tslib` (Class extending) usage in transpiled code is redundant nowadays as all the major browsers do support ES6, which has native classes support.
The concern with the `opera mini` in the MUI context is somewhat irrelevant as it was discussed and uncovered that it's basically an error on the MUI side and should be removed as [babel ignores it anyways](https://github.com/babel/babel/issues/8545).

**P.S.**: Do note that technically this should be a major bump to signal users, that the new release requires an environment supporting at least ES6.