### PR TITLE
fix(js-jods): Propert support for date-only and time-only in mergeDateAndTime method

### DIFF
--- a/__tests__/js-joda.test.ts
+++ b/__tests__/js-joda.test.ts
@@ -1,0 +1,20 @@
+import { LocalDate, LocalTime, LocalDateTime } from '@js-joda/core';
+import JsJodaUtils from "../packages/js-joda/src";
+
+describe("js-joda", () => {
+  const jsJodaUtils = new JsJodaUtils();
+
+  it("Merges a date with a non-time", () => {
+    const one = LocalDateTime.of(2022, 12, 5, 9, 30);
+    const two = LocalDate.of(2022, 12, 6);
+
+    expect(jsJodaUtils.mergeDateAndTime(one, two)).toEqual(one);
+  });
+
+  it("Merges a non-date with a time", () => {
+    const one = LocalTime.of(9, 30);
+    const two = LocalDateTime.of(2022, 12, 5, 9, 30);
+
+    expect(jsJodaUtils.mergeDateAndTime(one, two)).toEqual(two);
+  });
+});

--- a/packages/js-joda/src/js-joda-utils.ts
+++ b/packages/js-joda/src/js-joda-utils.ts
@@ -436,12 +436,20 @@ export default class JsJodaUtils implements IUtils<Temporal> {
   }
 
   mergeDateAndTime(date: Temporal, time: Temporal): Temporal {
-    var qtime = time.query(TemporalQueries.localTime());
-    if (qtime == null) {
-      /* istanbul ignore next */
+    const qdate = date.query(TemporalQueries.localDate());
+    const qtime = time.query(TemporalQueries.localTime());
+    if (qdate && qtime) {
+      return qdate.atTime(qtime);
+    } else if (!qdate) {
+      // A time merged with a non-date gives the original time.
+      return time;
+    } else if (!qtime) {
+      // A date merged with a non-time gives the original date.
       return date;
     } else {
-      return LocalDate.from(date).atTime(LocalTime.from(time));
+      // Fallback / error behavior
+      /* istanbul ignore next */
+      return date;
     }
   }
 

--- a/packages/js-joda/src/js-joda-utils.ts
+++ b/packages/js-joda/src/js-joda-utils.ts
@@ -443,12 +443,9 @@ export default class JsJodaUtils implements IUtils<Temporal> {
     } else if (!qdate) {
       // A time merged with a non-date gives the original time.
       return time;
-    } else if (!qtime) {
-      // A date merged with a non-time gives the original date.
-      return date;
     } else {
-      // Fallback / error behavior
-      /* istanbul ignore next */
+      // A date merged with a non-time gives the original date.  We also use
+      // this as the fallback / error behavior.
       return date;
     }
   }


### PR DESCRIPTION
See https://github.com/mui/mui-x/issues/4703#issuecomment-1192821687 (although note that mui-x no longer uses date-io).